### PR TITLE
Fix save directory bug

### DIFF
--- a/gerbilizer/main.py
+++ b/gerbilizer/main.py
@@ -110,8 +110,6 @@ def validate_args(args):
     # place output directly into directory user provides if bare flag is enabled
     if args.bare:
         args.model_dir = args.save_path
-        if not path.exists(args.model_dir):
-            pathlib.Path(args.model_dir).mkdir(exist_ok=True, parents=True)
     else:
         args.model_dir = path.join(
             args.save_path,
@@ -119,7 +117,7 @@ def validate_args(args):
             args.config_data["GENERAL"]["CONFIG_NAME"],
             f"{args.job_id:0>5d}",
         )
-        pathlib.Path(args.model_dir).mkdir(parents=True, exist_ok=True)
+    pathlib.Path(args.model_dir).mkdir(parents=True, exist_ok=True)
 
 
 def run_eval(args: argparse.Namespace, trainer: Trainer):


### PR DESCRIPTION
When the bare argument is False, the model directory is never creating, causing the script to crash. This addresses that by creating the directory.

I tested it once and it seems to work.